### PR TITLE
remove abstract get method from AjaxcomTrait

### DIFF
--- a/src/Controller/AjaxcomTrait.php
+++ b/src/Controller/AjaxcomTrait.php
@@ -12,6 +12,9 @@ use Symfony\Component\HttpFoundation\Response;
  * Class BaseController.
  *
  * @author Ivan Barlog <ivan.barlog@everlution.sk>
+ *
+ * The trait expects you provide a get($service) method,
+ * for example via Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait
  */
 trait AjaxcomTrait
 {
@@ -88,6 +91,4 @@ trait AjaxcomTrait
 
         return $this;
     }
-
-    abstract protected function get($id);
 }


### PR DESCRIPTION
compatibility with Symfony4 - broke on `composer install --optimize-autoloader`